### PR TITLE
feat: docker: configure arguments in command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install -r /tmp/requirements.txt
 RUN mkdir /promqtt
 COPY . /promqtt
 
-CMD ["python", "-u", "/promqtt/promqtt.py"]
+ENTRYPOINT ["python", "-u", "/promqtt/promqtt.py"]


### PR DESCRIPTION
For easier configuration run in docker allow set configuration in command part
After change:
``` 
> docker run promqtt:local --help
usage: promqtt.py [-h] [--http.interface HTTP.INTERFACE]
                  [--http.port HTTP.PORT] [--mqtt.broker MQTT.BROKER]
                  [--mqtt.port MQTT.PORT] [--verbose VERBOSE]
                  [--cfgfile CFGFILE]

Tasmota MQTT to Prometheus exporter.

optional arguments:
  -h, --help            show this help message and exit
  --http.interface HTTP.INTERFACE
                        Interface to bind the http server to.
  --http.port HTTP.PORT
                        TCP port for the http server.
  --mqtt.broker MQTT.BROKER
                        MQTT broker hostname
  --mqtt.port MQTT.PORT
                        MQTT broker port number
  --verbose VERBOSE     Verbose (debug) output.
  --cfgfile CFGFILE     Device configuration file
```

For example:
```
> docker run -v ./config.yml:/config.yml:ro promqtt:local --http.port 80 --mqtt.broker mqtt.local --cfgfile /config.yml
```